### PR TITLE
fixed pattern JSONs for JS 12, 23, 99

### DIFF
--- a/JS/12_nan/12_nan.json
+++ b/JS/12_nan/12_nan.json
@@ -4,7 +4,7 @@
     "family": "code_pattern_js",
     "tags": [],
     "instances": [
-        "./1_instance_12_NaN/1_instance_12_NaN.json"
+        "./1_instance_12_nan/1_instance_12_nan.json"
     ],
     "version": "v0.draft"
 }

--- a/JS/23_foreach_in_nested/23_foreach_in_nested.json
+++ b/JS/23_foreach_in_nested/23_foreach_in_nested.json
@@ -4,7 +4,7 @@
     "family": "code_pattern_js",
     "tags": [],
     "instances": [
-        "./1_instance_23_forEach_in_nested/1_instance_23_forEach_in_nested.json"
+        "./1_instance_23_foreach_in_nested/1_instance_23_foreach_in_nested.json"
     ],
     "version": "v0.draft"
 }

--- a/JS/99_get_ajax/99_get_ajax.json
+++ b/JS/99_get_ajax/99_get_ajax.json
@@ -4,7 +4,7 @@
     "family": "code_pattern_js",
     "tags": [],
     "instances": [
-        "./1_instance_99_GET_ajax/1_instance_99_GET_ajax.json"
+        "./1_instance_99_get_ajax/1_instance_99_get_ajax.json"
     ],
     "version": "v0.draft"
 }


### PR DESCRIPTION
The `instances` field in the pattern JSONs for javascript patterns 12, 23 and 99 had small spelling mistakes, the framework cannot find these instances.